### PR TITLE
Add Next.js scaffold for CloseHack-style real estate site

### DIFF
--- a/kyle-site/.eslintrc.json
+++ b/kyle-site/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/kyle-site/.gitignore
+++ b/kyle-site/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.DS_Store
+npm-debug.log*

--- a/kyle-site/README.md
+++ b/kyle-site/README.md
@@ -1,0 +1,28 @@
+# Kyle Site (Next.js)
+
+CloseHack-style real estate layout scaffold with route structure ready for IDX and lead capture integrations.
+
+## Routes
+
+- /
+- /search
+- /search/local
+- /search/featured
+- /home-valuation
+- /buying
+- /selling
+- /communities/[slug]
+- /about
+- /about/meet-kyle
+- /about/join
+- /testimonials
+- /contact
+- /login
+- /signup
+
+## Run
+
+```bash
+npm install
+npm run dev
+```

--- a/kyle-site/app/about/join/page.tsx
+++ b/kyle-site/app/about/join/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function JoinPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Join Our Team" description="Opportunities for agents who want modern systems and high-touch mentorship." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/about/meet-kyle/page.tsx
+++ b/kyle-site/app/about/meet-kyle/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function MeetKylePage() {
+  return (
+    <PageShell>
+      <RouteHero title="Meet Kyle" description="Bio, credentials, and local market experience across South Florida." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/about/page.tsx
+++ b/kyle-site/app/about/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function AboutPage() {
+  return (
+    <PageShell>
+      <RouteHero title="About" description="Learn about Kyle, our team culture, and how we support Miami buyers and sellers." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/buying/page.tsx
+++ b/kyle-site/app/buying/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function BuyingPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Buying" description="Step-by-step buyer guidance from financing through closing." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/communities/[slug]/page.tsx
+++ b/kyle-site/app/communities/[slug]/page.tsx
@@ -1,0 +1,15 @@
+import PageShell from "@/components/PageShell";
+
+export default async function CommunityPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const community = slug.replaceAll("-", " ");
+
+  return (
+    <PageShell>
+      <section className="mx-auto max-w-6xl px-4 py-16">
+        <h1 className="text-3xl font-semibold capitalize">{community}</h1>
+        <p className="mt-3 max-w-3xl text-slate-600">Neighborhood insights, active homes, schools, and market snapshots for {community}.</p>
+      </section>
+    </PageShell>
+  );
+}

--- a/kyle-site/app/contact/page.tsx
+++ b/kyle-site/app/contact/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function ContactPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Contact" description="Reach out for showings, listing consultations, or relocation support." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/globals.css
+++ b/kyle-site/app/globals.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color: #0f172a;
+  background: #ffffff;
+}
+
+body {
+  @apply bg-white text-slate-900 antialiased;
+}

--- a/kyle-site/app/home-valuation/page.tsx
+++ b/kyle-site/app/home-valuation/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function HomeValuationPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Home Valuation" description="Get an instant estimated value and request an expert pricing strategy." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/layout.tsx
+++ b/kyle-site/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Kyle Kleinman | Real Estate",
+  description: "Find a home with Kyle"
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body className="bg-white text-slate-900">{children}</body>
+    </html>
+  );
+}

--- a/kyle-site/app/login/page.tsx
+++ b/kyle-site/app/login/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function LoginPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Login" description="Access saved searches, favorite listings, and account tools." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/page.tsx
+++ b/kyle-site/app/page.tsx
@@ -1,0 +1,42 @@
+import PageShell from "@/components/PageShell";
+
+export default function Home() {
+  return (
+    <PageShell>
+      <section className="bg-slate-50 py-16">
+        <div className="mx-auto max-w-5xl px-4">
+          <h1 className="text-4xl font-semibold">Find a Home With Kyle</h1>
+          <div className="mt-6 flex gap-2">
+            <input placeholder="Search Area, City, or Zip..." className="flex-1 rounded-xl border px-4 py-3" />
+            <button className="rounded-xl bg-slate-900 px-6 py-3 text-white hover:bg-slate-950">Search</button>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-10 px-4 py-16 md:grid-cols-2">
+        <div>
+          <h2 className="text-3xl font-semibold">Where Your Real Estate Dreams Come True!</h2>
+          <p className="mt-4 max-w-3xl text-slate-600">
+            We offer full-service representation, local market expertise, and technology-powered support for every step in your move.
+          </p>
+          <button className="mt-6 rounded-xl bg-slate-900 px-6 py-3 text-white hover:bg-slate-950">Contact Us</button>
+        </div>
+        <form className="rounded-2xl border p-6 shadow-sm">
+          <h3 className="text-xl font-semibold">Get Listing Alerts</h3>
+          <p className="mt-2 text-sm text-slate-600">Tell us what you&apos;re searching for and we&apos;ll send matching homes.</p>
+          <div className="mt-4 space-y-3">
+            <input className="w-full rounded-xl border px-3 py-2" placeholder="Name" />
+            <input className="w-full rounded-xl border px-3 py-2" placeholder="Email" />
+            <input className="w-full rounded-xl border px-3 py-2" placeholder="Preferred Area" />
+            <button className="w-full rounded-xl bg-slate-900 px-4 py-2 text-white">Submit</button>
+          </div>
+        </form>
+      </section>
+
+      <section className="bg-slate-50 py-16 text-center">
+        <h2 className="text-3xl font-semibold">Buying &amp; Selling</h2>
+        <p className="mt-2 text-slate-600">Whether you&apos;re ready to buy or sell, get a tailored plan and concierge-level guidance.</p>
+      </section>
+    </PageShell>
+  );
+}

--- a/kyle-site/app/search/featured/page.tsx
+++ b/kyle-site/app/search/featured/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function FeaturedSearchPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Featured Listings" description="Hand-picked properties currently highlighted by Kyle Kleinman." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/search/local/page.tsx
+++ b/kyle-site/app/search/local/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function LocalSearchPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Local Search" description="Explore Miami neighborhoods with area-focused search filters and insights." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/search/page.tsx
+++ b/kyle-site/app/search/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function SearchPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Property Search" description="Browse active listings, map search, and saved searches in one place." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/selling/page.tsx
+++ b/kyle-site/app/selling/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function SellingPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Selling" description="Marketing plans, pricing strategy, and staging guidance to maximize your sale." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/signup/page.tsx
+++ b/kyle-site/app/signup/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function SignupPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Sign Up" description="Create an account to track listings and receive instant updates." />
+    </PageShell>
+  );
+}

--- a/kyle-site/app/testimonials/page.tsx
+++ b/kyle-site/app/testimonials/page.tsx
@@ -1,0 +1,10 @@
+import PageShell from "@/components/PageShell";
+import RouteHero from "@/components/RouteHero";
+
+export default function TestimonialsPage() {
+  return (
+    <PageShell>
+      <RouteHero title="Testimonials" description="What clients say about the buying and selling experience with Kyle." />
+    </PageShell>
+  );
+}

--- a/kyle-site/components/Footer.tsx
+++ b/kyle-site/components/Footer.tsx
@@ -1,0 +1,20 @@
+export default function Footer() {
+  return (
+    <footer className="border-t bg-slate-50">
+      <div className="mx-auto grid max-w-6xl gap-6 px-4 py-10 text-sm text-slate-600 md:grid-cols-3">
+        <div>
+          <h3 className="font-semibold text-slate-900">Legal</h3>
+          <p className="mt-2">All information is deemed reliable but not guaranteed.</p>
+        </div>
+        <div>
+          <h3 className="font-semibold text-slate-900">IDX Disclaimer</h3>
+          <p className="mt-2">Listing information provided by participating MLS boards.</p>
+        </div>
+        <div>
+          <h3 className="font-semibold text-slate-900">Brokerage</h3>
+          <p className="mt-2">Southeast Miami Realty • Licensed in Florida.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/kyle-site/components/Header.tsx
+++ b/kyle-site/components/Header.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+const navItems = [
+  { href: "/", label: "Home" },
+  {
+    href: "/search",
+    label: "Search",
+    children: [
+      { href: "/search/local", label: "Local Search" },
+      { href: "/search/featured", label: "Featured Listings" }
+    ]
+  },
+  { href: "/buying", label: "Buying" },
+  { href: "/selling", label: "Selling" },
+  { href: "/communities/miami-beach", label: "Communities" },
+  {
+    href: "/about",
+    label: "About",
+    children: [
+      { href: "/about/meet-kyle", label: "Meet Kyle" },
+      { href: "/about/join", label: "Join" },
+      { href: "/testimonials", label: "Testimonials" }
+    ]
+  },
+  { href: "/contact", label: "Contact" }
+];
+
+export default function Header() {
+  return (
+    <header className="border-b">
+      <div className="mx-auto max-w-6xl px-4 py-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <img src="https://images.unsplash.com/photo-1546961329-78bef0414d7c?auto=format&fit=crop&w=140&q=80" alt="Kyle Kleinman" className="h-14 w-14 rounded-full object-cover" />
+            <div>
+              <div className="text-lg font-semibold">Kyle Kleinman</div>
+              <div className="text-sm text-slate-600">(305) 972-4118 • kyle@southeast.miami</div>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Link href="/login" className="rounded-xl border px-4 py-2 text-sm">Login</Link>
+            <Link href="/signup" className="rounded-xl bg-slate-900 px-4 py-2 text-sm text-white">Sign Up</Link>
+          </div>
+        </div>
+        <nav className="mt-6 flex flex-wrap gap-6 text-sm font-medium">
+          {navItems.map((item) => (
+            <div key={item.href} className="group relative">
+              <Link href={item.href} className="hover:text-slate-600">
+                {item.label}
+              </Link>
+              {item.children ? (
+                <div className="invisible absolute left-0 top-full z-10 mt-3 w-48 rounded-xl border bg-white p-2 opacity-0 shadow-md transition group-hover:visible group-hover:opacity-100">
+                  {item.children.map((child) => (
+                    <Link key={child.href} href={child.href} className="block rounded-lg px-3 py-2 hover:bg-slate-50">
+                      {child.label}
+                    </Link>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/kyle-site/components/PageShell.tsx
+++ b/kyle-site/components/PageShell.tsx
@@ -1,0 +1,12 @@
+import Footer from "@/components/Footer";
+import Header from "@/components/Header";
+
+export default function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </>
+  );
+}

--- a/kyle-site/components/RouteHero.tsx
+++ b/kyle-site/components/RouteHero.tsx
@@ -1,0 +1,8 @@
+export default function RouteHero({ title, description }: { title: string; description: string }) {
+  return (
+    <section className="mx-auto max-w-6xl px-4 py-16">
+      <h1 className="text-3xl font-semibold">{title}</h1>
+      <p className="mt-3 max-w-3xl text-slate-600">{description}</p>
+    </section>
+  );
+}

--- a/kyle-site/next-env.d.ts
+++ b/kyle-site/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/kyle-site/next.config.ts
+++ b/kyle-site/next.config.ts
@@ -1,0 +1,14 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com"
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/kyle-site/package.json
+++ b/kyle-site/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "kyle-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.1.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "lucide-react": "0.469.0"
+  },
+  "devDependencies": {
+    "typescript": "5.7.2",
+    "@types/node": "22.10.1",
+    "@types/react": "19.0.2",
+    "@types/react-dom": "19.0.2",
+    "eslint": "9.17.0",
+    "eslint-config-next": "15.1.0",
+    "tailwindcss": "3.4.16",
+    "postcss": "8.4.49",
+    "autoprefixer": "10.4.20"
+  }
+}

--- a/kyle-site/postcss.config.js
+++ b/kyle-site/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/kyle-site/tailwind.config.ts
+++ b/kyle-site/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+} satisfies Config;

--- a/kyle-site/tsconfig.json
+++ b/kyle-site/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation

- Provide an owned, extensible Next.js + Tailwind codebase that reproduces the CloseHack real-estate template and flow so future IDX/AI/SaaS work can be built on it.
- Use Next.js (App Router) as the primary platform to support lead capture, auth, and future integrations instead of a vendor CMS.
- Recreate the exact site structure and conversion flow (agent header, mega-nav, hero search, lead form, listings, legal/IDX footer, auth) as routes for easy extension.

### Description

- Added a new `kyle-site` app scaffold with project config files including `package.json`, `tsconfig.json`, `next.config.ts`, `tailwind.config.ts`, and `postcss.config.js` plus `app/globals.css` for the design baseline.
- Implemented core UI components `Header`, `Footer`, `PageShell`, and `RouteHero`, and wired `app/layout.tsx` to use the global styles and metadata.
- Created all requested routes and pages under `app/` (including `/`, `/search`, `/search/local`, `/search/featured`, `/home-valuation`, `/buying`, `/selling`, `/communities/[slug]`, `/about`, `/about/meet-kyle`, `/about/join`, `/testimonials`, `/contact`, `/login`, `/signup`) and added a lead-capture form on the homepage.
- Added `.eslintrc.json`, `.gitignore`, and `kyle-site/README.md` with run instructions for local development.

### Testing

- Verified presence of all required route files with a Python path check which returned no missing files.
- Attempted dependency installation with `npm --prefix kyle-site install` but the install failed due to HTTP 403 errors from the npm registry, preventing runtime build or dev server startup.
- Attempted a Playwright screenshot against `http://127.0.0.1:3000` but the capture failed with `ERR_EMPTY_RESPONSE` because the dev server could not be started without installed dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19440abac8321b3b50886bfa81d96)